### PR TITLE
Allow gh token to publish

### DIFF
--- a/.github/workflows/template.yml
+++ b/.github/workflows/template.yml
@@ -1,7 +1,12 @@
 name: Apply template
+
 on:
   push:
     branches: [main]
+
+# Required so `git push` works with GITHUB_TOKEN
+permissions:
+  contents: write
 
 jobs:
   apply:
@@ -11,37 +16,49 @@ jobs:
       - uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
 
       - name: Check if already applied
         id: check
+        shell: bash
         run: |
-          [ -f .template-applied ] && echo "skip=true" >> $GITHUB_OUTPUT || echo "skip=false" >> $GITHUB_OUTPUT
+          if [ -f .template-applied ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Substitute placeholders
         if: steps.check.outputs.skip == 'false'
+        shell: bash
         env:
           REPO: ${{ github.event.repository.name }}
           OWNER: ${{ github.repository_owner }}
         run: |
-          find . -not -path './.git/*' \( -name "*.yml" -o -name "*.md" \) | \
-            xargs sed -i \
+          find . -not -path './.git/*' \( -name "*.yml" -o -name "*.md" \) -print0 | \
+            xargs -0 sed -i \
               -e "s|{{cookiecutter.repo_name}}|$REPO|g" \
               -e "s|{{cookiecutter.github_username}}|$OWNER|g" \
               -e "s|{{cookiecutter.site_name}}|$REPO|g"
 
       - name: Restructure for participant delivery
         if: steps.check.outputs.skip == 'false'
+        shell: bash
         run: |
           rm -rf docs/instructor/ setup/ CONTRIBUTING.md CITATION.cff
           sed -i '/# INSTRUCTOR_START/,/# INSTRUCTOR_END/d' mkdocs.yml
 
       - name: Commit and self-destruct
         if: steps.check.outputs.skip == 'false'
+        shell: bash
         run: |
+          set -euo pipefail
           touch .template-applied
-          rm .github/workflows/template.yml
+          rm -f .github/workflows/template.yml
+
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
           git add -A
           git commit -m "Apply template"
-          git push
+          git push origin HEAD:main


### PR DESCRIPTION
This pull request updates the `.github/workflows/template.yml` workflow to improve reliability, security, and cross-platform compatibility. The main changes include updating permissions for the workflow, ensuring consistent shell usage, improving file handling in scripts, and making the Git push step more robust.

**Workflow permissions and configuration:**

* Added explicit `permissions: contents: write` to allow the workflow to push changes using the `GITHUB_TOKEN`.

**Shell and script improvements:**

* Specified `shell: bash` for all relevant steps to ensure consistent execution across environments.
* Improved conditional logic in the "Check if already applied" step for better readability and reliability.

**File handling and cross-platform compatibility:**

* Updated the placeholder substitution command to use `find ... -print0` and `xargs -0` for safer handling of filenames with spaces or special characters.
* Changed `rm` commands to use the `-f` flag for safe deletion even if the file does not exist.

**Git operations:**

* Modified the final `git push` to explicitly push to `origin HEAD:main`, making the operation more robust and explicit.
* Added `set -euo pipefail` to the commit step for stricter error handling in the script.