### PR TITLE
Fix broken tip links

### DIFF
--- a/docs/instructor/materials.md
+++ b/docs/instructor/materials.md
@@ -32,13 +32,13 @@ Below are lesson notes from trainers who have previously delivered this workshop
 
     ---
 
-    [:octicons-arrow-right-24: Part 1 - Nextflow fundamentals](instructor/pt1-guide.md)
+    [:octicons-arrow-right-24: Part 1 - Nextflow fundamentals](pt1-guide.md)
 
 -   :fontawesome-solid-hand:{ .lg .middle } **Part 2 - Build a workflow**
 
     ---
 
-    [:octicons-arrow-right-24: Part 2 - Building a workflow](instructor/pt2-guide.md)
+    [:octicons-arrow-right-24: Part 2 - Building a workflow](pt2-guide.md)
 
 </div>
 


### PR DESCRIPTION
This pull request updates internal links in the instructor materials documentation to ensure they point to the correct guide files. 

Documentation updates:

* Updated links in `docs/instructor/materials.md` so that "Part 1 - Nextflow fundamentals" and "Part 2 - Building a workflow" now link to `pt1-guide.md` and `pt2-guide.md` respectively, instead of the previous `instructor/pt1-guide.md` and `instructor/pt2-guide.md` paths.