### PR TITLE
Fix/setup path

### DIFF
--- a/setup/README.md
+++ b/setup/README.md
@@ -59,6 +59,13 @@ modularity:
 ./install.sh
 ```
 
+!!! info
+
+    On bioshell hosts (where `shelley-bio` is available and
+    `/cvmfs/singularity.galaxyproject.org/all` is mounted), the install script
+    creates symlinks to CVMFS container images instead of downloading them.
+    On all other hosts, the script downloads container images as usual.
+
 If prompted with the following, select **"install the package maintainer's 
 version"**
 

--- a/setup/README.md
+++ b/setup/README.md
@@ -81,16 +81,24 @@ successful for this user. In this example, the default user is `ubuntu`.
 Once the install script has been run successfuly, there are a few more steps to
 prepare the machine to be workshop-ready.
 
+The installer copies the runtime Part 2 workshop files from
+`docs/workshop/part2/materials/` into the learner's home directory.
+
 After the test run, you should see the following files and folders:
 
 ```console
 ubuntu@ttt-fj-image-2:~$ tree -L 2 $HOME
 /home/ubuntu
-├── nf4ls-data
-│   ├── install.sh
-│   ├── lib
-│   ├── part2
-│   └── README.md
+├── nf4ls-materials
+│   ├── CITATION.cff
+│   ├── CODE_OF_CONDUCT.md
+│   ├── CONTRIBUTING.md
+│   ├── cookiecutter.json
+│   ├── docs
+│   ├── LICENSE
+│   ├── mkdocs.yml
+│   ├── README.md
+│   └── setup
 ├── part1
 ├── part2
 │   ├── bash_scripts
@@ -118,7 +126,7 @@ and the setup repository files are ready to be deleted:
 cd ${HOME} && \
 rm -fv ${HOME}/part2/*.html ${HOME}/part2/*.txt ${HOME}/part2/.nextflow.log* && \
 rm -rfv ${HOME}/part2/.nextflow ${HOME}/part2/results ${HOME}/part2/work && \
-rm -rfv ${HOME}/nf4ls-data
+rm -rfv ${HOME}/nf4ls-materials
 ```
 
 Lastly, ensure that the environmental variables (for example, `SINGULARITY_CACHEDIR`) is sourced correctly. This will be automatically be applied upon login.
@@ -132,9 +140,8 @@ source ${HOME}/.bashrc
 After successfuly installation, and cleaning up the machines, the final file
 structure should look as follows:
 
-```bash
+```consol
 tree ${HOME}
-```console
 /home/ubuntu
 ├── part1 # Empty
 ├── part2
@@ -171,7 +178,8 @@ The `part1` folder is left intentionally empty as the learners will create scrip
 
 **Part 2**
 
-The `part2` folder contains several files for the workshop:
+The installer copies the `docs/workshop/part2/materials/` folder into the
+learner's `part2/` directory. That folder contains several files for the workshop:
 
 - `bash_scripts/` includes example scripts of the pipeline that learners will
 be implementing in Nextflow. These are never run, but serve as an example of

--- a/setup/install.sh
+++ b/setup/install.sh
@@ -54,10 +54,17 @@ log "Pulling biocontainers"
 # [0]: Link to pull container
 # [1]: Amended name for nextflow to recognise
 IMAGES=(
-	"quay.io/biocontainers/salmon:1.10.1--h7e5ed60_0 quay.io-biocontainers-salmon-1.10.1--h7e5ed60_0.img"
-	"quay.io/biocontainers/fastqc:0.12.1--hdfd78af_0 quay.io-biocontainers-fastqc-0.12.1--hdfd78af_0.img"
-	"quay.io/biocontainers/multiqc:1.19--pyhdfd78af_0 quay.io-biocontainers-multiqc-1.19--pyhdfd78af_0.img"
+	"quay.io/biocontainers/salmon:1.10.1--h7e5ed60_0 quay.io-biocontainers-salmon-1.10.1--h7e5ed60_0.img salmon:1.10.1--h7e5ed60_0"
+	"quay.io/biocontainers/fastqc:0.12.1--hdfd78af_0 quay.io-biocontainers-fastqc-0.12.1--hdfd78af_0.img fastqc:0.12.1--hdfd78af_0"
+	"quay.io/biocontainers/multiqc:1.19--pyhdfd78af_0 quay.io-biocontainers-multiqc-1.19--pyhdfd78af_0.img multiqc:1.19--pyhdfd78af_0"
 )
+
+CVMFS_ROOT="/cvmfs/singularity.galaxyproject.org/all"
+USE_CVMFS_SYMLINKS=false
+if command -v shelley-bio >/dev/null 2>&1 && [[ -d "${CVMFS_ROOT}" ]]; then
+	USE_CVMFS_SYMLINKS=true
+	log "bioshell detected - using CVMFS symlinks for containers"
+fi
 
 # Export cachedir in .bashrc 
 if grep -q "SINGULARITY_CACHEDIR" ~/.bashrc; then
@@ -77,11 +84,17 @@ mkdir -p ${SINGULARITY_CACHEDIR}
 # by adding "docker://" 
 for image in "${IMAGES[@]}"; do
 	# unpack string by " "
-	read -r url img <<< $image
-	if [[ ! -f "${SINGULARITY_CACHEDIR}/${img}" ]]; then
-		singularity pull "${SINGULARITY_CACHEDIR}/${img}" "docker://${url}"
-	else
+	read -r url img cvmfs_img <<< "$image"
+	cache_path="${SINGULARITY_CACHEDIR}/${img}"
+	cvmfs_path="${CVMFS_ROOT}/${cvmfs_img}"
+
+	if [[ -e "${cache_path}" || -L "${cache_path}" ]]; then
 		log "Skipping ${img} (already exists)"
+	elif [[ "${USE_CVMFS_SYMLINKS}" == true && -f "${cvmfs_path}" ]]; then
+		ln -s "${cvmfs_path}" "${cache_path}"
+		log "Linked ${img} -> ${cvmfs_path}"
+	else
+		singularity pull "${cache_path}" "docker://${url}"
 	fi
 done
 

--- a/setup/lib/prep_files.sh
+++ b/setup/lib/prep_files.sh
@@ -6,9 +6,14 @@ prep_files () {
 	# Create empty directory for part 1 and mv part 2 contents
 	# from the data repo
 	local BASEPATH=$1
+	local SCRIPT_DIR REPO_ROOT SOURCE_PART2
 
-	if [[ ! -d "part2" ]]; then
-		log "No workshop files to copy. Are you sure you are in the nf4ls-data directory?"
+	SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+	REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+	SOURCE_PART2="${REPO_ROOT}/docs/workshop/part2/materials"
+
+	if [[ ! -d "${SOURCE_PART2}" ]]; then
+		log "No workshop files to copy. Expected to find ${SOURCE_PART2}."
 		exit 1
 	fi
 
@@ -18,7 +23,7 @@ prep_files () {
 	fi
 
 	mkdir -p "${BASEPATH}/part1"
-	cp -rv part2 "${BASEPATH}/part2"
+	cp -rv "${SOURCE_PART2}/." "${BASEPATH}/part2"
 
 	log "Workshop files ready to go!"
 }


### PR DESCRIPTION
## Description

Fixes the workshop setup process by correcting file paths and improving container handling.

### Changes

- **Path corrections**: Updated references from `nf4ls-data` to `nf4ls-materials` throughout setup documentation and scripts
- **Smart container handling**: Install script now detects bioshell environments and creates symlinks to CVMFS container images instead of downloading them
- **Dynamic file sourcing**: `prep_files.sh` now locates workshop materials from `docs/workshop/part2/materials/` using repository-relative paths instead of assuming a fixed directory structure
- **Documentation updates**: Clarified setup process and expected directory structure in README

### Files Modified

- `setup/README.md` - Updated paths and added bioshell information
- `setup/install.sh` - Added CVMFS symlink detection and container image reference updates
- `setup/lib/prep_files.sh` - Fixed file path resolution logic